### PR TITLE
Support windows and WSL

### DIFF
--- a/denops/chameleon/checker.ts
+++ b/denops/chameleon/checker.ts
@@ -10,6 +10,9 @@ function getChecker(): (
       return checkDarkmodeDarwin;
     }
     case "linux": {
+      if (Deno.env.has("WSL_DISTRO_NAME")) {
+        return checkDarkmodeWindows;
+      }
       return checkDarkmodeLinux;
     }
     case "windows": {

--- a/denops/chameleon/checker.ts
+++ b/denops/chameleon/checker.ts
@@ -48,10 +48,23 @@ function checkDarkmodeLinux(
   return Promise.resolve("dark");
 }
 
-function checkDarkmodeWindows(
-  _options: { signal?: AbortSignal },
+async function checkDarkmodeWindows(
+  { signal }: { signal?: AbortSignal },
 ): Promise<Background> {
-  console.warn(`Windows is not supported yet. PR is welcome!`);
+  const cmd = new Deno.Command("powershell.exe", {
+    args: [
+      "-command",
+      '$regValue = Get-ItemProperty -Path "HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize" -Name "AppsUseLightTheme"; Write-Output $regValue.AppsUseLightTheme',
+    ],
+    stdin: "null",
+    stdout: "piped",
+    stderr: "null",
+    signal,
+  });
+  const { success, stdout } = await cmd.output();
+  if (success) {
+    return decoder.decode(stdout).trim() === "0" ? "dark" : "light";
+  }
   return Promise.resolve("dark");
 }
 


### PR DESCRIPTION
I implemented #1.
Checked it out in Windows and WSL, I confirmed that it is worked well.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced theme detection for Windows users, now supporting asynchronous checks for dark mode.
	- Added support for identifying the Windows theme based on system settings.
- **Bug Fixes**
	- Improved control flow for determining background theme across different operating systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->